### PR TITLE
Updated html translator to 1.0.8

### DIFF
--- a/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/AllTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/AllTests.cs
@@ -15,8 +15,8 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
 <p>To get some work experience you could:</p>
 <ul>
 <li>volunteer to commentate on charity events like fun runs</li>
-<li>commentate for amateur matches at schools, college or for local teams</li>
-<li>record commentary for websites or internet radio stations</li>
+<li>commentate for amateur matches at schools, college or for local teams </li>
+<li> record commentary for websites or internet radio stations </li>
 <li>volunteer for community, hospital or student radio, or TV</li>
 </ul>
 <p>You can get a list of radio stations from:</p>
@@ -35,10 +35,10 @@ for work experience.</p>
             Assert.Equal("You'll need to have some practical experience and be able to show you have a real enthusiasm for sports commentating.", outputValue.ElementAt(0));
             Assert.Equal("To get some work experience you could:volunteer to commentate on charity events like fun runs; commentate for amateur matches at schools, college or for local teams; record commentary for websites or internet radio stations; volunteer for community, hospital or student radio, or TV", outputValue.ElementAt(1));
             Assert.Equal("You can get a list of radio stations from:[Community Media Association | http://www.commedia.org.uk/]; [Hospital Broadcasting Association | http://www.hbauk.com/]; [RadioCentre | http://www.radiocentre.org/]", outputValue.ElementAt(2));
-            Assert.Equal("Large broadcasters like[BBC Careers | https://www.bbc.co.uk/careers/work-experience/],[ITV | http://www.itvjobs.com/workinghere/entry-careers/]and[Channel 4 | https://careers.channel4.com/4talent]offer work experience placements, insight and talent days.", outputValue.ElementAt(3));
-            Assert.Equal("The[Sports Journalists ’ Association | https://www.sportsjournalists.co.uk/training/work-experience/]has more ideas about where to look \r\nfor work experience.", outputValue.ElementAt(4));
+            Assert.Equal("Large broadcasters like [BBC Careers | https://www.bbc.co.uk/careers/work-experience/], [ITV | http://www.itvjobs.com/workinghere/entry-careers/]   and [Channel 4 | https://careers.channel4.com/4talent] offer work experience placements, insight and talent days.", outputValue.ElementAt(3));
+            Assert.Equal("The [Sports Journalists ’ Association | https://www.sportsjournalists.co.uk/training/work-experience/] has more ideas about where to look \r\nfor work experience.", outputValue.ElementAt(4));
             Assert.Equal("With experience", outputValue.ElementAt(5));
-            Assert.Equal("You could move into other roles. Find more[information | http://ncs.com]here", outputValue.ElementAt(6));
+            Assert.Equal("You could move into other roles. Find more [information | http://ncs.com] here", outputValue.ElementAt(6));
         }
     }
 }

--- a/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/LineBreakTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/LineBreakTests.cs
@@ -10,6 +10,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
         [InlineData("content1<br/>content2")]
         [InlineData("content1<br/><p>content2</p>")]
         [InlineData("content1<br/><br/>content2")]
+        [InlineData("<p>content1<br/><br/>content2</p>")]
         public void CanTranslateLineBreaks(string sourceValue)
         {
             var translator = new HtmlAgilityPackDataTranslator();

--- a/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/MixedTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/MixedTests.cs
@@ -48,7 +48,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
             var outputValue = translator.Translate(sourceValue);
             Assert.Equal(3, outputValue.Count);
             Assert.Equal("p1", outputValue.ElementAt(0));
-            Assert.Equal("this is some[link1 | http://www.yahoo.com]content", outputValue.ElementAt(1));
+            Assert.Equal("this is some [link1 | http://www.yahoo.com]content", outputValue.ElementAt(1));
             Assert.Equal("p2", outputValue.ElementAt(2));
         }
 
@@ -56,10 +56,10 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
         public void CanTranslateTextWithLinks()
         {
             var translator = new HtmlAgilityPackDataTranslator();
-            var sourceValue = @"content non in html tags <a href='http://www.google.com'>link1</a> more content";
+            var sourceValue = @"content not in html tags <a href='http://www.google.com'>link1</a> more content";
             var outputValue = translator.Translate(sourceValue);
             Assert.Single(outputValue);
-            Assert.Equal("content non in html tags[link1 | http://www.google.com]more content", outputValue.ElementAt(0));
+            Assert.Equal("content not in html tags [link1 | http://www.google.com] more content", outputValue.ElementAt(0));
         }
     }
 }

--- a/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/ParagraphWithLinksTest.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/ParagraphWithLinksTest.cs
@@ -13,7 +13,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
             var sourceValue = @"<p>Large broadcasters like&nbsp;<a href=""https://www.bbc.co.uk/careers/work-experience/"">BBC Careers</a>, <a href=""http://www.itvjobs.com/workinghere/entry-careers/"">ITV</a>&nbsp;and <a href=""https://careers.channel4.com/4talent"">Channel 4</a> offer work experience placements, insight and talent days.</p>";
             var outputValue = translator.Translate(sourceValue);
             Assert.Single(outputValue);
-            Assert.Equal("Large broadcasters like[BBC Careers | https://www.bbc.co.uk/careers/work-experience/],[ITV | http://www.itvjobs.com/workinghere/entry-careers/]and[Channel 4 | https://careers.channel4.com/4talent]offer work experience placements, insight and talent days.", outputValue.First());
+            Assert.Equal("Large broadcasters like [BBC Careers | https://www.bbc.co.uk/careers/work-experience/], [ITV | http://www.itvjobs.com/workinghere/entry-careers/] and [Channel 4 | https://careers.channel4.com/4talent] offer work experience placements, insight and talent days.", outputValue.First());
         }
     }
 }

--- a/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/SpacesTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/HtmlAgilityPackDataTranslatorTests/SpacesTests.cs
@@ -13,6 +13,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.HtmlAgilityPackDataTranslatorTests
         [InlineData("<p>content </p>", "content")]
         [InlineData("<p> content</p>", "content")]
         [InlineData("<p> content </p>", "content")]
+        [InlineData(" <p> content </p> ", "content")]
         public void ContentWithSpacesIsTrimmed(string sourceValue, string expectedValue)
         {
             var translator = new HtmlAgilityPackDataTranslator();

--- a/DFC.HtmlToDataTranslator.UnitTests/Rules/ConvertLinksToTextRuleTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/Rules/ConvertLinksToTextRuleTests.cs
@@ -1,0 +1,27 @@
+﻿using DFC.HtmlToDataTranslator.Rules;
+using Xunit;
+
+namespace DFC.HtmlToDataTranslator.UnitTests.Rules
+{
+    public class ConvertLinksToTextRuleTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("<a href='http://www.google.com'>link1</a>", "[link1 | http://www.google.com]")]
+        [InlineData("<a href=''>link1</a>", "[link1 | ]")]
+        [InlineData("<a>link1</a>", "[link1 | ]")]
+        [InlineData(" <a>link1</a> ", " [link1 | ] ")]
+        [InlineData(" <p id=p1>p1</p> ", " <p id=p1>p1</p> ")]
+        [InlineData("<p id=p1>p1</p>", "<p id=p1>p1</p>")]
+        [InlineData("<p id=p1><a href='http://www.google.com'>link1</a></p>", "<p id=p1>[link1 | http://www.google.com]</p>")]
+        [InlineData("<p><a href='page1'>link1</a> <div>div1</div> <a href=page2>link2</a></p>", "<p>[link1 | page1] <div>div1</div> [link2 | page2]</p>")]
+        [InlineData(" <a href='page1'>link1</a> <a>link2</a> <a href>link3</a> ", " [link1 | page1] [link2 | ] [link3 | ] ")]
+        public void CanApplyRule(string source, string expected)
+        {
+            var rule = new ConvertLinksToTextRule();
+            var actual = rule.Process(source);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/DFC.HtmlToDataTranslator.UnitTests/Rules/DecodeHtmlRuleTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/Rules/DecodeHtmlRuleTests.cs
@@ -1,0 +1,32 @@
+﻿using DFC.HtmlToDataTranslator.Rules;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace DFC.HtmlToDataTranslator.UnitTests.Rules
+{
+    public class DecodeHtmlRuleTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("<p>content1&nbsp; content2</p>", "<p>content1  content2</p>")]
+        [InlineData("<p>content1&pound; content2</p>", "<p>content1£ content2</p>")]
+        [InlineData("<p>content1&ndash; content2</p>", "<p>content1– content2</p>")]
+        [InlineData("<p>content1&amp; content2</p>", "<p>content1& content2</p>")]
+        [InlineData("<p>content1&lsquo; content2</p>", "<p>content1‘ content2</p>")]
+        [InlineData("<p>content1&rsquo; content2</p>", "<p>content1’ content2</p>")]
+        [InlineData("<p>content1&copy; content2</p>", "<p>content1© content2</p>")]
+        [InlineData("<p>content1&lt; content2</p>", "<p>content1< content2</p>")]
+        [InlineData("<p>content1&gt; content2</p>", "<p>content1> content2</p>")]
+        [InlineData("<p>content1&le; content2</p>", "<p>content1≤ content2</p>")]
+        [InlineData("<p>content1&ge; content2</p>", "<p>content1≥ content2</p>")]
+        public void ReplaceBrTagsWithPTags(string source, string expected)
+        {
+            var rule = new DecodeHtmlRule();
+            var actual = rule.Process(source);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/DFC.HtmlToDataTranslator.UnitTests/Rules/DecodeHtmlRuleTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/Rules/DecodeHtmlRuleTests.cs
@@ -1,7 +1,4 @@
 ﻿using DFC.HtmlToDataTranslator.Rules;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace DFC.HtmlToDataTranslator.UnitTests.Rules
@@ -22,7 +19,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.Rules
         [InlineData("<p>content1&gt; content2</p>", "<p>content1> content2</p>")]
         [InlineData("<p>content1&le; content2</p>", "<p>content1≤ content2</p>")]
         [InlineData("<p>content1&ge; content2</p>", "<p>content1≥ content2</p>")]
-        public void ReplaceBrTagsWithPTags(string source, string expected)
+        public void CanApplyRule(string source, string expected)
         {
             var rule = new DecodeHtmlRule();
             var actual = rule.Process(source);

--- a/DFC.HtmlToDataTranslator.UnitTests/Rules/ReplaceBrTagsWithPTagsRuleTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/Rules/ReplaceBrTagsWithPTagsRuleTests.cs
@@ -16,7 +16,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.Rules
         [InlineData("<p>some content<br /></p>", "<p>some content</p><p></p>")]
         [InlineData("<p id='p1'>some content<br></p>", "<p id='p1'>some content</p><p></p>")]
         [InlineData("<p id='p1'>some content<br><br/></p>", "<p id='p1'>some content</p><p></p><p></p>")]
-        public void CanAppluRule(string source, string expected)
+        public void CanApplyRule(string source, string expected)
         {
             var rule = new ReplaceBrTagsWithPTagsRule();
             var actual = rule.Process(source);

--- a/DFC.HtmlToDataTranslator.UnitTests/Rules/ReplaceBrTagsWithPTagsRuleTests.cs
+++ b/DFC.HtmlToDataTranslator.UnitTests/Rules/ReplaceBrTagsWithPTagsRuleTests.cs
@@ -16,7 +16,7 @@ namespace DFC.HtmlToDataTranslator.UnitTests.Rules
         [InlineData("<p>some content<br /></p>", "<p>some content</p><p></p>")]
         [InlineData("<p id='p1'>some content<br></p>", "<p id='p1'>some content</p><p></p>")]
         [InlineData("<p id='p1'>some content<br><br/></p>", "<p id='p1'>some content</p><p></p><p></p>")]
-        public void ReplaceBrTagsWithPTags(string source, string expected)
+        public void CanAppluRule(string source, string expected)
         {
             var rule = new ReplaceBrTagsWithPTagsRule();
             var actual = rule.Process(source);

--- a/DFC.HtmlToDataTranslator/Contracts/IPreProcessorRule.cs
+++ b/DFC.HtmlToDataTranslator/Contracts/IPreProcessorRule.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DFC.HtmlToDataTranslator.Contracts
+﻿namespace DFC.HtmlToDataTranslator.Contracts
 {
     public interface IPreProcessorRule
     {

--- a/DFC.HtmlToDataTranslator/DFC.HtmlToDataTranslator.csproj
+++ b/DFC.HtmlToDataTranslator/DFC.HtmlToDataTranslator.csproj
@@ -5,7 +5,7 @@
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <Description>Convert html into a list of strings</Description>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/DFC.HtmlToDataTranslator/Rules/ConvertLinksToTextRule.cs
+++ b/DFC.HtmlToDataTranslator/Rules/ConvertLinksToTextRule.cs
@@ -1,0 +1,99 @@
+﻿using DFC.HtmlToDataTranslator.Constants;
+using DFC.HtmlToDataTranslator.Contracts;
+using HtmlAgilityPack;
+using System;
+
+namespace DFC.HtmlToDataTranslator.Rules
+{
+    public class ConvertLinksToTextRule : IPreProcessorRule
+    {
+        public string Process(string html)
+        {
+            var tagNameStart = "<a";
+            var tagNameEnd = "</a>";
+
+            if (string.IsNullOrWhiteSpace(html))
+            {
+                return html;
+            }
+
+            var result = string.Empty;
+            var currentPosition = 0;
+            var linkStartPosition = html.IndexOf(tagNameStart, StringComparison.OrdinalIgnoreCase);
+            if (linkStartPosition == -1)
+            {
+                result = html;
+            }
+
+            while (linkStartPosition != -1)
+            {
+                var linkEndPosition = html.IndexOf(tagNameEnd, linkStartPosition, StringComparison.OrdinalIgnoreCase);
+                if (linkEndPosition != -1)
+                {
+                    var linkHtml = html.Substring(linkStartPosition, linkEndPosition - linkStartPosition + tagNameEnd.Length);
+                    var linkHtmlDoc = new HtmlDocument();
+                    linkHtmlDoc.LoadHtml(linkHtml);
+                    var linkHref = GetHref(linkHtmlDoc);
+                    var linkText = GetText(linkHtmlDoc);
+                    var newLinkText = $"[{linkText} | {linkHref}]";
+
+                    var textBeforeLink = string.Empty;
+
+                    if (currentPosition == 0)
+                    {
+                        textBeforeLink = html.Substring(currentPosition, linkStartPosition);
+                    }
+                    else
+                    {
+                        textBeforeLink = html.Substring(currentPosition + tagNameEnd.Length, linkStartPosition - currentPosition - tagNameEnd.Length);
+                    }
+
+                    result += textBeforeLink + newLinkText;
+                    currentPosition = linkEndPosition;
+                    linkStartPosition = html.IndexOf(tagNameStart, linkStartPosition + 1, StringComparison.OrdinalIgnoreCase);
+
+                    if (linkStartPosition == -1 && linkEndPosition > 0)
+                    {
+                        var remainder = html.Substring(linkEndPosition + tagNameEnd.Length);
+                        result += remainder;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private string GetHref(HtmlDocument htmlDocument)
+        {
+            var result = string.Empty;
+            var node = htmlDocument.DocumentNode.SelectSingleNode("a");
+            if (node != null)
+            {
+                var hrefAttribute = node.Attributes[HtmlAttributeName.Href];
+                if (hrefAttribute != null)
+                {
+                    result = hrefAttribute.Value;
+                }
+            }
+
+            return result;
+        }
+
+        private string GetText(HtmlDocument htmlDocument)
+        {
+            var result = string.Empty;
+            var node = htmlDocument.DocumentNode.SelectSingleNode("a");
+            if (node != null)
+            {
+                result = node.InnerText;
+
+                if (!string.IsNullOrWhiteSpace(result))
+                {
+                    result = result.Trim();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/DFC.HtmlToDataTranslator/Rules/DecodeHtmlRule.cs
+++ b/DFC.HtmlToDataTranslator/Rules/DecodeHtmlRule.cs
@@ -1,0 +1,13 @@
+﻿using DFC.HtmlToDataTranslator.Contracts;
+using HtmlAgilityPack;
+
+namespace DFC.HtmlToDataTranslator.Rules
+{
+    public class DecodeHtmlRule : IPreProcessorRule
+    {
+        public string Process(string html)
+        {
+            return HtmlEntity.DeEntitize(html);
+        }
+    }
+}

--- a/DFC.HtmlToDataTranslator/Services/HtmlAgilityPackDataTranslator.cs
+++ b/DFC.HtmlToDataTranslator/Services/HtmlAgilityPackDataTranslator.cs
@@ -15,10 +15,10 @@ namespace DFC.HtmlToDataTranslator.Services
                 var nodeToStringListConvertor = new HtmlNodesToStringListConverter();
                 var rulesProcessor = new RulesProcessor();
 
-                var contentAfterRulesProcessor = rulesProcessor.Process(value);
+                var proProcessedContent = rulesProcessor.Process(value);
 
                 var htmlDoc = new HtmlDocument();
-                htmlDoc.LoadHtml(contentAfterRulesProcessor);
+                htmlDoc.LoadHtml(proProcessedContent);
 
                 var nodes = ParseNodes(htmlDoc);
                 result = nodeToStringListConvertor.Convert(nodes);

--- a/DFC.HtmlToDataTranslator/Services/HtmlAgilityPackDataTranslator.cs
+++ b/DFC.HtmlToDataTranslator/Services/HtmlAgilityPackDataTranslator.cs
@@ -15,10 +15,10 @@ namespace DFC.HtmlToDataTranslator.Services
                 var nodeToStringListConvertor = new HtmlNodesToStringListConverter();
                 var rulesProcessor = new RulesProcessor();
 
-                var proProcessedContent = rulesProcessor.Process(value);
+                var preProcessedContent = rulesProcessor.Process(value);
 
                 var htmlDoc = new HtmlDocument();
-                htmlDoc.LoadHtml(proProcessedContent);
+                htmlDoc.LoadHtml(preProcessedContent);
 
                 var nodes = ParseNodes(htmlDoc);
                 result = nodeToStringListConvertor.Convert(nodes);

--- a/DFC.HtmlToDataTranslator/Services/HtmlNodesToStringListConverter.cs
+++ b/DFC.HtmlToDataTranslator/Services/HtmlNodesToStringListConverter.cs
@@ -149,21 +149,8 @@ namespace DFC.HtmlToDataTranslator.Services
                 result = htmlNode.InnerText;
                 if (!string.IsNullOrWhiteSpace(result))
                 {
-                    result = PerformReplace(result);
-
                     result = result.Trim();
                 }
-            }
-
-            return result;
-        }
-
-        private string PerformReplace(string sourceValue)
-        {
-            var result = sourceValue;
-            if (!string.IsNullOrWhiteSpace(sourceValue))
-            {
-                result = HtmlEntity.DeEntitize(sourceValue);
             }
 
             return result;

--- a/DFC.HtmlToDataTranslator/Services/HtmlNodesToStringListConverter.cs
+++ b/DFC.HtmlToDataTranslator/Services/HtmlNodesToStringListConverter.cs
@@ -67,10 +67,6 @@ namespace DFC.HtmlToDataTranslator.Services
             {
                 result = TranslateList(htmlNode, SeperatorSemicolonWithSpace);
             }
-            else if (IsLink(htmlNode))
-            {
-                result = TranslateLink(htmlNode);
-            }
             else if (htmlNode.ChildNodes.Any())
             {
                 var childNodeTranslated = TranslateChildren(htmlNode);
@@ -100,17 +96,6 @@ namespace DFC.HtmlToDataTranslator.Services
             }
 
             return result;
-        }
-
-        private string TranslateLink(HtmlNode htmlNode)
-        {
-            var hrefValue = string.Empty;
-            if (htmlNode.Attributes.Contains(HtmlAttributeName.Href))
-            {
-                hrefValue = htmlNode.Attributes[HtmlAttributeName.Href].Value;
-            }
-
-            return $"[{ParseText(htmlNode)} | {hrefValue}]";
         }
 
         private string TranslateList(HtmlNode htmlNode, string seperator)

--- a/DFC.HtmlToDataTranslator/Services/RulesProcessor.cs
+++ b/DFC.HtmlToDataTranslator/Services/RulesProcessor.cs
@@ -21,8 +21,9 @@ namespace DFC.HtmlToDataTranslator.Services
         private IEnumerable<IPreProcessorRule> GetRules()
         {
             var rules = new List<IPreProcessorRule>();
-            rules.Add(new ReplaceBrTagsWithPTagsRule());
             rules.Add(new DecodeHtmlRule());
+            rules.Add(new ReplaceBrTagsWithPTagsRule());
+            rules.Add(new ConvertLinksToTextRule());
             return rules;
         }
     }

--- a/DFC.HtmlToDataTranslator/Services/RulesProcessor.cs
+++ b/DFC.HtmlToDataTranslator/Services/RulesProcessor.cs
@@ -22,6 +22,7 @@ namespace DFC.HtmlToDataTranslator.Services
         {
             var rules = new List<IPreProcessorRule>();
             rules.Add(new ReplaceBrTagsWithPTagsRule());
+            rules.Add(new DecodeHtmlRule());
             return rules;
         }
     }


### PR DESCRIPTION
Spacing for links is preserved.
Added a new pre processor rule for links to text
Added a decode html rule
Refactored translator to not to link translation or decoding
Added more test and fixed issues with existing ones
Added more rule tests